### PR TITLE
Add GPIO operation upon request to feed dogs

### DIFF
--- a/raspberry/rpi-server/rpi-server.cabal
+++ b/raspberry/rpi-server/rpi-server.cabal
@@ -16,13 +16,16 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     Lib
-  other-modules:       ServerAPI
+  other-modules:       RPIO
+                     , ServerAPI
                      , Types
   build-depends:       base >= 4.7 && < 5
                      , aeson
                      , attoparsec
                      , base-compat
                      , bytestring
+                     , exceptions
+                     , hpio
                      , lucid
                      , mtl
                      , servant-server

--- a/raspberry/rpi-server/src/RPIO.hs
+++ b/raspberry/rpi-server/src/RPIO.hs
@@ -1,0 +1,19 @@
+module RPIO 
+  ( openWaitAndClosePin
+  ) where
+
+import Control.Concurrent
+import Control.Monad.Except
+import System.GPIO.Monad
+import System.GPIO.Linux.Sysfs
+
+openWaitAndClosePin
+  :: Int 
+  -> IO () 
+openWaitAndClosePin pinNum = runOperation $ do
+  withOutputPin (Pin pinNum) OutputDefault Nothing High $ \h -> do
+    liftIO $ threadDelay 5
+    writeOutputPin h Low
+
+runOperation :: SysfsGpioIO () -> IO () 
+runOperation = void . runSysfsGpioIO

--- a/raspberry/rpi-server/src/ServerAPI.hs
+++ b/raspberry/rpi-server/src/ServerAPI.hs
@@ -20,6 +20,7 @@ import Types
 
 import qualified Control.Exception as E
 import Control.Monad.Except
+import Data.ByteString.Lazy.Char8
 import Data.Time.Clock.POSIX
 import Network.Wai
 import Network.Wai.Handler.Warp
@@ -58,7 +59,7 @@ handlePinOperation :: IO () -> Handler String
 handlePinOperation operation = do
   opOrError <- liftIO operationOrError
   case opOrError of
-    Left _ -> throwError $ err500 { errBody = "Pin Operation Failed" }
+    Left e -> throwError $ err500 { errBody = pack (E.displayException e) }
     Right _ -> return "SUCCESS"
   where
     operationOrError :: IO (Either SomeGpioException ())


### PR DESCRIPTION
Add a simple operation to open a pin, wait for some time and then exit.  Catch GPIO exceptions during the operation phase as well and surface them in an HTTP error.

Tested by making curl requests and and noting error codes.  We don't have a way to mock the pi yet, but since we don't have a working version yet, we can do that later 